### PR TITLE
Add 69shuba.com scraping support

### DIFF
--- a/assets/config/default.js
+++ b/assets/config/default.js
@@ -28,6 +28,10 @@ const main_def = {
         'RawHTML':{
             func: rawChapter,
             inputs: {}
+        },
+        '69shuba': {
+            func: shuba69_chapter,
+            inputs: {}
         }
     }
 }
@@ -62,6 +66,31 @@ function meta_page(dom, url) {
  * publisher: string,
  * title: string}}
  */
+/**
+ * Gets metadata from 69shuba book pages
+ * @param {HTMLElement} dom
+ * @param {string} url
+ * @returns {{title:string, description:string, author:string, cover:string, publisher:string}}
+ */
+function meta_69shuba(dom, url) {
+    let scriptText = Array.from(dom.querySelectorAll('script'))
+        .map(s => s.textContent).join('\n')
+    let title = (scriptText.match(/articlename[n]?\s*:\s*'([^']+)'/) || [])[1]
+    let author = (scriptText.match(/author\s*:\s*'([^']+)'/) || [])[1]
+    let cover = dom.querySelector('.pic img')?.src ||
+                dom.querySelector('.bookimg img')?.src
+    let desc = dom.querySelector('.intro')?.innerHTML ||
+               dom.querySelector('.describe')?.innerHTML
+    return {
+        title: title || dom.title,
+        description: desc,
+        author: author || 'N/A',
+        cover: cover,
+        publisher: '69书吧'
+    }
+}
+
+
 function meta_nu(dom, url) {
     let tit = dom.querySelector(".seriestitlenu").innerText;
     let desc = dom.querySelector("#editdescription").innerHTML;
@@ -165,6 +194,27 @@ function main_parser(inputs, url, source, helpers) {
                     }
                 }
             }
+        case "www.69shuba.com":
+            if (paths.length > 1 && paths[1] === 'book') {
+                let isDetailPage = paths[2] && paths[2].includes('.htm')
+                let msg = isDetailPage
+                    ? 'Detected 69shuba (book detail page). Click "Complete TOC" to get all chapters. Select "69shuba" as text parser.'
+                    : 'Detected 69shuba TOC page. Select "69shuba" as text parser.'
+                return {
+                    message: msg,
+                    meta: meta_69shuba(dom, url),
+                    parser_opt: {
+                        type: 'links',
+                        parser: 'Chapter Links',
+                        chap_parser: '69shuba',
+                        parser_inputs: {
+                            'Query Selector': 'a[href*="/txt/"]',
+                            'Link Regex': '\\S'
+                        }
+                    }
+                }
+            }
+            return {failed_message: 'Please navigate to a 69shuba book page (/book/XXXXX.htm or /book/XXXXX/).'}
     }
     if (dom.querySelector('.md-nav--primary>.md-nav__list>.md-nav__item--active > .md-nav')) {
         return {
@@ -300,6 +350,52 @@ function rawChapter(inputs, url, source, helpers) {
         title: out.title,
         html: out.content,
         message: "Parsed simple chapter"
+    };
+}
+
+
+/**
+ * Parse 69shuba chapter page
+ * Chapter content is inside <div class="txtnav"> after stripping nav/ad elements
+ * @param inputs
+ * @param url
+ * @param source
+ * @param helpers
+ * @returns {{html:string, title:string, message:string}}
+ */
+function shuba69_chapter(inputs, url, source, helpers) {
+    let parser = new DOMParser();
+    let dom = parser.parseFromString(source, 'text/html');
+    // JS chaptername is always clean (no site suffix); fall back to h1, then page title
+    let scriptText = Array.from(dom.querySelectorAll('script'))
+        .map(s => s.textContent).join('\n');
+    let title = (scriptText.match(/chaptername\s*:\s*'([^']+)'/) || [])[1]?.trim()
+        || dom.querySelector('.txtnav h1')?.textContent?.trim()
+        || dom.title.replace(/[-_\s]*69书吧\s*$/i, '').trim();
+
+    let txtnav = dom.querySelector('.txtnav');
+    if (!txtnav) {
+        let out = helpers['readability'](dom);
+        if (!out) return {title: title || url, html: '<div>Chapter load failed (may be blocked by Cloudflare)</div>', message: '403 or page parse failed'};
+        return {title: out.title || title || url, html: out.content, message: 'Parsed 69shuba chapter (readability)'};
+    }
+
+    // Remove non-content elements: ads, nav, title, date info
+    txtnav.querySelectorAll(
+        'h1, .txtinfo, #txtright, .tools, .yueduad1, script, .bottom_page, .pagebox, .bottom_ad'
+    ).forEach(el => el.remove());
+
+    // 69shuba puts &emsp;&emsp; indent at START of each paragraph (before text, not after <br>).
+    // Split on <br>, strip leading whitespace/nbsp from each segment, then rejoin.
+    let html = txtnav.innerHTML
+        .split(/<br\s*\/?>/i)
+        .map(seg => seg.replace(/^(?:\s|&nbsp;|&#160;|&emsp;|&#8195;|&#12288;|[\u00a0\u2003\u3000])+/, ''))
+        .join('<br/>');
+
+    return {
+        title: title,
+        html: '<div>' + html + '</div>',
+        message: 'Parsed 69shuba chapter'
     };
 }
 

--- a/src/services/scraping/ParserMan.ts
+++ b/src/services/scraping/ParserMan.ts
@@ -140,7 +140,7 @@ export default class ParserManager {
 
       parser_chap.value = {
         doc: parse_doc,
-        parser: Object.keys(this.parsers[parse_doc].text)[0]
+        parser: parser_opt.chap_parser || Object.keys(this.parsers[parse_doc].text)[0]
       }
       p_inputs_val_text.value = get_default_inputs(this.parsers[parse_doc]
         .text[parser_chap.value.parser]['inputs'])
@@ -251,9 +251,8 @@ export default class ParserManager {
       const html5_cs = rawdom.querySelector('meta[charset]')
         ?.getAttribute('charset') ?? null
       if (html5_cs !== null){
-        const res = this.parseContentType(html5_cs)
-        if (res)
-          return res
+        // <meta charset="gbk"> gives a bare charset value, use it directly
+        return html5_cs.toLowerCase()
       }
 
       const html4_cs = rawdom.querySelector('meta[http-equiv=Content-Type]')

--- a/src/services/scraping/parser_types.ts
+++ b/src/services/scraping/parser_types.ts
@@ -44,6 +44,7 @@ export interface AddDetected {
 export interface ParserDetected {
   type: 'links' | 'text'
   parser: string
+  chap_parser?: string
   parser_inputs?: Record<string, any>
 }
 


### PR DESCRIPTION
- Add meta_69shuba() to extract book metadata (title, author, cover, desc)
- Add shuba69_chapter() text parser: extracts content from .txtnav, strips ads/nav, removes paragraph indentation (&emsp;), cleans title
- Add detector case for www.69shuba.com (/book/* pages)
- Add chap_parser field to ParserDetected to allow link-type detectors to specify a preferred text parser (used here to auto-select 69shuba)
- Fix getCharset() to return bare <meta charset="..."> value directly instead of passing it through content-type parser (fixes GBK decoding)